### PR TITLE
load-test: General fixes and improvements

### DIFF
--- a/contrib/perf-check-status.sh
+++ b/contrib/perf-check-status.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# This script checks the status of all inputs and outputs and reports
+# if any status is not "ok". Exits with non-zero code if issues found.
+
+set -euo pipefail
+
+exit_code=0
+unhealthy_inputs=()
+unhealthy_outputs=()
+
+input_status=$(edge input list | awk 'NR>1 {$1=""; print $2, substr($0, index($0,$3))}')
+if [[ -n "$input_status" ]]; then
+    while IFS=' ' read -r name health_rest; do
+        if [[ ! "$health_rest" =~ ✓ ]]; then
+            # Extract just the status message part (after the indicator)
+            clean_status=$(echo "$health_rest" | sed 's/\x1b\[[0-9;]*m//g' | sed 's/^[✗✓] *//')
+            unhealthy_inputs+=("$name|$clean_status")
+            exit_code=1
+        fi
+    done <<< "$input_status"
+fi
+
+output_status=$(edge output list | awk 'NR>1 {$1=""; print $2, substr($0, index($0,$3))}')
+if [[ -n "$output_status" ]]; then
+    while IFS=' ' read -r name health_rest; do
+        if [[ ! "$health_rest" =~ ✓ ]]; then
+            # Extract just the status message part (after the indicator)
+            clean_status=$(echo "$health_rest" | sed 's/\x1b\[[0-9;]*m//g' | sed 's/^[✗✓] *//')
+            unhealthy_outputs+=("$name|$clean_status")
+            exit_code=1
+        fi
+    done <<< "$output_status"
+fi
+
+if [[ ${#unhealthy_inputs[@]} -gt 0 ]]; then
+    echo "Found unhealthy inputs:"
+    for item in "${unhealthy_inputs[@]}"; do
+        name="${item%%|*}"
+        status="${item#*|}"
+        printf "  %-40s %s\n" "$name" "$status"
+    done
+fi
+
+if [[ ${#unhealthy_outputs[@]} -gt 0 ]]; then
+    echo "Found unhealthy outputs:"
+    for item in "${unhealthy_outputs[@]}"; do
+        name="${item%%|*}"
+        status="${item#*|}"
+        printf "  %-40s %s\n" "$name" "$status"
+    done
+fi
+
+if [[ $exit_code -eq 0 ]]; then
+    echo "✅ All OK"
+else
+    echo "❌ Found inputs/outputs with non-ok status"
+fi
+
+exit $exit_code

--- a/contrib/perf-cleanup.sh
+++ b/contrib/perf-cleanup.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# This script deletes ALL inputs and outputs whose names start with "Perftest"
+# Use with extreme caution - this action cannot be undone!
+
+set -euo pipefail
+
+# Get all inputs starting with Perftest
+perftest_inputs=$(edge input list | awk 'NR>1 && $2 ~ /^Perftest/ {print $2}')
+# Get all outputs starting with Perftest
+perftest_outputs=$(edge output list | awk 'NR>1 && $2 ~ /^Perftest/ {print $2}')
+
+input_count=$(echo "$perftest_inputs" | grep -c . 2>/dev/null || echo 0)
+output_count=$(echo "$perftest_outputs" | grep -c . 2>/dev/null || echo 0)
+
+# Handle empty strings properly
+if [[ -z "$perftest_inputs" ]]; then
+    input_count=0
+fi
+if [[ -z "$perftest_outputs" ]]; then
+    output_count=0
+fi
+
+if [[ $input_count -eq 0 && $output_count -eq 0 ]]; then
+    echo "No inputs or outputs found."
+    exit 0
+fi
+
+echo "Found:"
+echo "  - $input_count inputs starting with 'Perftest'"
+echo "  - $output_count outputs starting with 'Perftest'"
+echo
+echo "⚠️  WARNING: This will delete $input_count inputs and $output_count outputs. This action cannot be undone!"
+echo
+echo "Are you sure you want to continue? (y/N): "
+read -r response
+
+if [[ ! "$response" =~ ^[Yy]$ ]]; then
+    echo "Operation cancelled."
+    exit 0
+fi
+
+echo
+
+# Function to delete an item with progress
+delete_item() {
+    local type=$1
+    local name=$2
+    edge "$type" delete "$name"
+}
+
+# Export function for parallel execution
+export -f delete_item
+export EDGE_URL EDGE_PASSWORD
+
+echo "Deleting inputs..."
+if [[ $input_count -gt 0 ]]; then
+    echo "$perftest_inputs" | xargs -I {} -P 10 bash -c 'delete_item input "{}"'
+fi
+
+echo "Deleting outputs..."
+if [[ $output_count -gt 0 ]]; then
+    echo "$perftest_outputs" | xargs -I {} -P 10 bash -c 'delete_item output "{}"'
+fi
+
+echo
+echo "Cleanup completed!"
+echo "   - Deleted $input_count inputs"
+echo "   - Deleted $output_count outputs"

--- a/contrib/video-perf-forwarding.sh
+++ b/contrib/video-perf-forwarding.sh
@@ -7,7 +7,7 @@
 # This test does not involve a video node in the traditional sense because the
 # stream isn't routed via a core node.
 
-bitrate="$((20 * 1000000))"
+bitrate="$((30 * 1000000))"
 test_appliance=dut
 protocol=srt
 fanout=1
@@ -51,9 +51,9 @@ set -euo pipefail
 generator_appliance=$(edge appliance list | awk '$3 == "edgeConnect" && $1 ~ /input/ { print $1 }' | sort | head)
 output_appliance=$(edge appliance list | awk '$3 == "edgeConnect" && $1 ~ /output/ { print $1 }' | sort | head)
 
-generator_interface=$(edge appliance show "$generator_appliance" | awk '/Name:/ { name=$3; found=0 } /Networks:.*streaming/ { found=1 } /Address:/ && found { print(name) }')
-read -r output_interface output_ip <<< "$(edge appliance show "$output_appliance" | awk '/Name:/ { name=$3; found=0 } /Networks:.*streaming/ { found=1 } /Address:/ && found { print(name, $3) }')"
-read -r test_interface test_ip <<< "$(edge appliance show "$test_appliance" | awk '/Name:/ { name=$3; found=0 } /Networks:.*streaming/ { found=1 } /Address:/ && found { print(name, $3) }')"
+generator_interface=$(edge appliance show "$generator_appliance" | awk '/Name:/ { name=$3 } /Address:.*\.201\./ && name != "lo" { print(name); exit }')
+read -r output_interface output_ip <<< "$(edge appliance show "$output_appliance" | awk '/Name:/ { name=$3 } /Address:.*\.201\./ && name != "lo" { print(name, $3); exit }')"
+read -r test_interface test_ip <<< "$(edge appliance show "$test_appliance" | awk '/Name:/ { name=$3 } /Address:.*\.201\./ && name != "lo" { print(name, $3); exit }')"
 
 cat >&2 <<EOF
 Generator appliance:    ${generator_appliance}
@@ -61,8 +61,8 @@ Output appliance:       ${output_appliance}
 Test appliance:         ${test_appliance}
 EOF
 
-inputs="$(edge input list | awk '/^ID/ { next } { print $2 }')"
-outputs="$(edge output list | awk '/^ID/ { next } { print $2 }')"
+inputs="$(edge input list --limit 1000 | awk '/^ID/ { next } { print $2 }')"
+outputs="$(edge output list --limit 1000 | awk '/^ID/ { next } { print $2 }')"
 
 echo >&2 "Setting up generators"
 

--- a/contrib/video-perf-test.sh
+++ b/contrib/video-perf-test.sh
@@ -33,6 +33,10 @@ while [[ $# -gt 0 ]]; do
             fanout="$2"
             shift 2
             ;;
+        --bitrate)
+            bitrate=$(numfmt --from=auto "${2}")
+            shift 2
+            ;;
         -v | --verbose)
             shift
             set -x

--- a/contrib/video-perf-test.sh
+++ b/contrib/video-perf-test.sh
@@ -20,9 +20,14 @@ fanout=1
 
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --disable-thumbnails)
-            input_extra_args+=("--disable-thumbnails")
-            shift
+        --thumbnail)
+            if [[ "$2" == "none" || "$2" == "core" || "$2" == "edge" ]]; then
+                input_extra_args+=("--thumbnail=$2")
+                shift 2
+            else
+                echo "Error: --thumbnail must be one of: none, core, edge"
+                exit 1
+            fi
             ;;
         --fanout)
             fanout="$2"
@@ -59,7 +64,7 @@ EOF
 # from edge-connect-input-edge-192-5 for example) of the appliance name
 # It might be possible to make this better by using the hostname field
 input_machines=("${input_appliances[@]%-*}")
-mapfile -t generator_appliances < <(printf "%s\n" "${input_machines[@]}" | sort -u)
+mapfile -t generator_appliances < <(printf "%s\n" "${input_machines[@]}" | sort -u | while read -r machine; do echo "${machine}-000"; done)
 
 inputs="$(edge input list | awk '/^ID/ { next } { print $2 }')"
 outputs="$(edge output list | awk '/^ID/ { next } { print $2 }')"
@@ -70,10 +75,9 @@ for appliance in "${generator_appliances[@]}"; do
     if ! grep -qw "Perftest-generator-$appliance" <<<"$inputs"; then
         edge input create "Perftest-generator-$appliance" \
             --appliance "$appliance" \
-            --interface lo \
             --mode generator \
             --bitrate "$bitrate" \
-            --disable-thumbnails
+            --thumbnail none
     fi
     if ! grep -qw "Perftest-generator-$appliance" <<<"$outputs"; then
         edge output create "Perftest-generator-$appliance" \

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -744,6 +744,7 @@ pub struct RtpInputPort {
     pub fec: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multicast_address: Option<String>,
+    pub whitelist_cidr_block: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -778,6 +779,7 @@ pub enum SrtInputPort {
         local_port: u16,
         reduced_bitrate_detection: bool,
         unrecovered_packets_detection: bool,
+        whitelist_cidr_block: Option<Vec<String>>,
     },
     Rendezvous,
 }
@@ -789,6 +791,7 @@ pub struct RistInputPort {
     pub address: String,
     pub port: u16,
     pub profile: String, // can only be 'simple'
+    pub whitelist_cidr_block: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1335,7 +1338,7 @@ impl EdgeClient {
         Ok(res.json::<LoginResp>()?.user)
     }
 
-    pub fn list_inputs(&self) -> Result<Vec<Input>, reqwest::Error> {
+    pub fn list_inputs(&self, limit: u32) -> Result<Vec<Input>, reqwest::Error> {
         #[derive(Debug, Deserialize)]
         struct InputListResp {
             items: Vec<Input>,
@@ -1344,7 +1347,10 @@ impl EdgeClient {
 
         let res = self
             .client
-            .get(format!(r#"{}/api/input/"#, self.url,))
+            .get(format!(
+                r#"{}/api/input/?q={{"filter":{{}},"skip":0,"limit":{}}}"#,
+                self.url, limit
+            ))
             .header("content-type", "application/json")
             .send()?;
 
@@ -1408,7 +1414,7 @@ impl EdgeClient {
             .map(|_| ())
     }
 
-    pub fn list_outputs(&self) -> Result<Vec<Output>, EdgeError> {
+    pub fn list_outputs(&self, limit: u32) -> Result<Vec<Output>, EdgeError> {
         #[derive(Debug, Deserialize)]
         struct OutputListResp {
             items: Vec<Output>,
@@ -1417,7 +1423,10 @@ impl EdgeClient {
 
         let res = self
             .client
-            .get(format!(r#"{}/api/output/"#, self.url,))
+            .get(format!(
+                r#"{}/api/output/?q={{"filter":{{}},"skip":0,"limit":{}}}"#,
+                self.url, limit
+            ))
             .header("content-type", "application/json")
             .send()?
             .error_if_not_success()?;

--- a/src/input.rs
+++ b/src/input.rs
@@ -79,6 +79,13 @@ pub(crate) fn subcommand() -> clap::Command {
                         .short('i')
                         .long("interface")
                         .required(false)
+                        .required_if_eq_any([
+                            ("mode", "rtp"),
+                            ("mode", "udp"),
+                            ("mode", "srt"),
+                            ("mode", "rist"),
+                            ("mode", "sdi"),
+                        ])
                         .help("The interface on the appliance to create the input on"),
                 )
                 .arg(

--- a/src/input.rs
+++ b/src/input.rs
@@ -28,14 +28,23 @@ pub(crate) fn subcommand() -> clap::Command {
         .about("Manage inputs")
         .subcommand_required(true)
         .subcommand(
-            Command::new("list").arg(
-                Arg::new("output")
-                    .long("output")
-                    .short('o')
-                    .value_parser(["short", "wide"])
-                    .default_value("short")
-                    .help("Change the output format"),
-            ),
+            Command::new("list")
+                .arg(
+                    Arg::new("output")
+                        .long("output")
+                        .short('o')
+                        .value_parser(["short", "wide"])
+                        .default_value("short")
+                        .help("Change the output format"),
+                )
+                .arg(
+                    Arg::new("limit")
+                        .long("limit")
+                        .short('l')
+                        .value_parser(clap::value_parser!(u32).range(1..=10000))
+                        .default_value("500")
+                        .help("Maximum number of inputs to return"),
+                ),
         )
         .subcommand(
             Command::new("show").arg(
@@ -194,9 +203,10 @@ pub(crate) fn run(subcmd: &ArgMatches) {
     match subcmd.subcommand() {
         Some(("list", args)) => {
             let client = new_client();
+            let limit = *args.get_one::<u32>("limit").unwrap_or(&500);
             if let Err(e) = match args.get_one::<String>("output").map(|s| s.as_str()) {
-                Some("wide") => list_wide(client),
-                _ => list(client),
+                Some("wide") => list_wide(client, limit),
+                _ => list(client, limit),
             } {
                 eprintln!("Failed to list inputs: {:?}", e);
                 process::exit(1);
@@ -513,8 +523,10 @@ mod tests {
     }
 }
 
-fn list(client: EdgeClient) -> anyhow::Result<()> {
-    let inputs = client.list_inputs().context("Failed to list edge inputs")?;
+fn list(client: EdgeClient, limit: u32) -> anyhow::Result<()> {
+    let inputs = client
+        .list_inputs(limit)
+        .context("Failed to list edge inputs")?;
     let mut builder = Builder::default();
     builder.push_record(["ID", "Name", "Health"]);
 
@@ -536,8 +548,8 @@ fn list(client: EdgeClient) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn list_wide(client: EdgeClient) -> anyhow::Result<()> {
-    let inputs = client.list_inputs().context("Failed to list inputs")?;
+fn list_wide(client: EdgeClient, limit: u32) -> anyhow::Result<()> {
+    let inputs = client.list_inputs(limit).context("Failed to list inputs")?;
     let mut groups = BTreeMap::new();
     let mut group_list = client.list_groups().context("Failed to list groups")?;
     while let Some(group) = group_list.pop() {
@@ -752,6 +764,7 @@ fn create(client: EdgeClient, new_input: NewInput) {
                 port: rtp.port,
                 fec: rtp.fec,
                 multicast_address: rtp.multicast_address.clone(),
+                whitelist_cidr_block: Some(vec!["0.0.0.0/0".to_owned()]),
             })]
         }
         NewInputMode::Udp(ref udp) => {
@@ -799,6 +812,7 @@ fn create(client: EdgeClient, new_input: NewInput) {
                 latency: 120,
                 reduced_bitrate_detection: false,
                 unrecovered_packets_detection: false,
+                whitelist_cidr_block: Some(vec!["0.0.0.0/0".to_owned()]),
             })]
         }
         NewInputMode::Rist(NewRistInputMode {
@@ -817,6 +831,7 @@ fn create(client: EdgeClient, new_input: NewInput) {
                     .to_owned(),
                 port,
                 profile: "simple".to_owned(),
+                whitelist_cidr_block: Some(vec!["0.0.0.0/0".to_owned()]),
             })]
         }
         NewInputMode::Sdi(ref sdi) => {

--- a/src/output.rs
+++ b/src/output.rs
@@ -17,14 +17,23 @@ pub(crate) fn subcommand() -> clap::Command {
         .about("Manage outputs")
         .subcommand_required(true)
         .subcommand(
-            Command::new("list").arg(
-                Arg::new("output")
-                    .long("output")
-                    .short('o')
-                    .value_parser(["short", "wide"])
-                    .default_value("short")
-                    .help("Change the output format"),
-            ),
+            Command::new("list")
+                .arg(
+                    Arg::new("output")
+                        .long("output")
+                        .short('o')
+                        .value_parser(["short", "wide"])
+                        .default_value("short")
+                        .help("Change the output format"),
+                )
+                .arg(
+                    Arg::new("limit")
+                        .long("limit")
+                        .short('l')
+                        .value_parser(clap::value_parser!(u32).range(1..=10000))
+                        .default_value("500")
+                        .help("Maximum number of outputs to return"),
+                ),
         )
         .subcommand(
             Command::new("show").arg(
@@ -139,9 +148,10 @@ pub(crate) fn run(subcmd: &ArgMatches) {
     match subcmd.subcommand() {
         Some(("list", args)) => {
             let client = new_client();
+            let limit = *args.get_one::<u32>("limit").unwrap_or(&500);
             match args.get_one::<String>("output").map(|s| s.as_str()) {
-                Some("wide") => list_wide(client),
-                _ => list(client),
+                Some("wide") => list_wide(client, limit),
+                _ => list(client, limit),
             };
         }
         Some(("show", args)) => {
@@ -395,8 +405,8 @@ impl Output {
     }
 }
 
-fn list(client: EdgeClient) {
-    let outputs = client.list_outputs().expect("Failed to list outputs");
+fn list(client: EdgeClient, limit: u32) {
+    let outputs = client.list_outputs(limit).expect("Failed to list outputs");
     let mut builder = Builder::default();
     builder.push_record(["ID", "Name", "Health"]);
 
@@ -410,8 +420,8 @@ fn list(client: EdgeClient) {
     println!("{}", table)
 }
 
-fn list_wide(client: EdgeClient) {
-    let outputs = client.list_outputs().expect("Failed to list outputs");
+fn list_wide(client: EdgeClient, limit: u32) {
+    let outputs = client.list_outputs(limit).expect("Failed to list outputs");
     let mut builder = Builder::default();
     builder.push_record([
         "ID",


### PR DESCRIPTION
This patch contains general fixes and improvements I found during load testing Edge.

It adds some convenience scripts and syncs the CLI client with the Edge API, such as `--disable-thumbnail` -> `--thumbnail none/core/edge`

It also adds a new `--limit` to the list input and outputs: `output list --limit 1000` for those large requests.