### PR TITLE
Don't needlessy iterate entire iterator

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -319,7 +319,7 @@ pub(crate) fn run(subcmd: &ArgMatches) {
                         let address = dest.split(':').next().expect("dest address is missing");
                         let port = dest
                             .split(':')
-                            .last()
+                            .next_back()
                             .expect("Port number is required for --dest")
                             .parse::<u16>()
                             .expect("port needs to be a number between 0 and 65535");

--- a/src/output.rs
+++ b/src/output.rs
@@ -220,7 +220,7 @@ pub(crate) fn run(subcmd: &ArgMatches) {
                     let address = dest.split(':').next().expect("dest address is missing");
                     let port = dest
                         .split(':')
-                        .last()
+                        .next_back()
                         .expect("Port number is required for --dest")
                         .parse::<u16>()
                         .expect("port needs to be a number between 0 and 65535");
@@ -262,7 +262,7 @@ pub(crate) fn run(subcmd: &ArgMatches) {
                     let address = dest.split(':').next().expect("dest address is missing");
                     let port = dest
                         .split(':')
-                        .last()
+                        .next_back()
                         .expect("Port number is required for --dest")
                         .parse::<u16>()
                         .expect("port needs to be a number between 0 and 65535");
@@ -284,7 +284,7 @@ pub(crate) fn run(subcmd: &ArgMatches) {
                         let address = dest.split(':').next().expect("dest address is missing");
                         let port = dest
                             .split(':')
-                            .last()
+                            .next_back()
                             .expect("Port number is required for --dest")
                             .parse::<u16>()
                             .expect("port needs to be a number between 0 and 65535");
@@ -321,7 +321,7 @@ pub(crate) fn run(subcmd: &ArgMatches) {
                     let address = dest.split(':').next().expect("dest address is missing");
                     let port = dest
                         .split(':')
-                        .last()
+                        .next_back()
                         .expect("Port number is required for --dest")
                         .parse::<u16>()
                         .expect("port needs to be a number between 0 and 65535");


### PR DESCRIPTION
This was a suggestion from cargo clippy, as well as a fix from it (cargo
clippy --fix)

```
warning: called `Iterator::last` on a `DoubleEndedIterator`; this will needlessly iterate the entire iterator
   --> src/output.rs:322:32
    |
322 |                       let port = dest
    |  ________________________________^
323 | |                         .split(':')
324 | |                         .last()
    | |__________________________-----^
    |                            |
    |                            help: try: `next_back()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last
```